### PR TITLE
Add SQL fragment literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Fragments work with references, too, and referenced fragments are cached instead
 of re-evaluated in the referencing column.
 Otherwise, declarations like `col2 @col1` below could lead to situations where
 they look like their values should be equal but are not if the fragment result
-is volatile as below with `statement_timestamp()`, calling `nextval('sequence_name')`, etc.
+is volatile as below with `statement_timestamp()`.
 
 ```
 table t1 (

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ See the corresponding [VS Code extension](https://github.com/kevlarr/vscode-hldr
    5. [Named records](#named-records)
    6. [References](#references)
    7. [Table aliases](#table-aliases)
+   8. [SQL fragments](#sql-fragments)
 5. [Planned features](#planned-features)
 
 ## Overview
@@ -39,6 +40,7 @@ Current language constructs include:
 - Primitive literal values: booleans, numbers, and text strings
 - References to previous columns in the same record or named records in either the same
   or any other table
+- SQL `select` fragment literals
 - Inline comments
 
 References are primarily what sets Placeholder apart from other declarative formats (eg. JSON),
@@ -296,6 +298,38 @@ table pet (
   ( person_id @p.p1.id )
 )
 ```
+
+### SQL Fragments
+
+Arbitrary `SELECT` statements can be embedded as values by using backticks and
+simply omitting the `SELECT` keyword.
+
+```
+table t1 (
+  (
+    col1 `now()`
+    col2 `current_timestamp`
+    col3 `ts from (select current_timestamp as ts) q`
+  )
+)
+```
+
+Fragments work with references, too, and referenced fragments are cached instead
+of re-evaluated in the referencing column.
+Otherwise, declarations like `col2 @col1` below could lead to situations where
+they look like their values should be equal but are not if the fragment result
+is volatile as below with `statement_timestamp()`, calling `nextval('sequence_name')`, etc.
+
+```
+table t1 (
+  (
+    col1 `statement_timestamp()` -- 2024-04-30 22:57:24.111111-04
+    col2 @col1                   -- 2024-04-30 22:57:24.111111-04
+    col3 `statement_timestamp()` -- 2024-04-30 22:57:27.333333-04
+  )
+)
+```
+
 
 ## Planned features
 

--- a/src/lexer/prelude.rs
+++ b/src/lexer/prelude.rs
@@ -38,9 +38,9 @@ pub(super) struct Stack {
 }
 
 impl Stack {
-    pub fn new(start_position: Position, c: char) -> Self {
+    pub fn new(start_position: Position, c: Option<char>) -> Self {
         Self {
-            content: String::from(c),
+            content: c.map(|c| String::from(c)).unwrap_or_default(),
             start_position,
         }
     }
@@ -62,12 +62,6 @@ impl Stack {
 pub trait State : any::Any + fmt::Debug {
     /// Receives a character (or `None` when EOF) and returns the next state.
     fn receive(self: Box<Self>, ctx: &mut Context, c: Option<char>) -> ReceiveResult;
-
-    /// Returns whether or not the given character can successfully terminate the current state,
-    /// defaulting to only allowing whitespace, newlines, or EOF to terminate.
-    fn can_terminate(&self, c: Option<char>) -> bool {
-        c.is_none() || matches!(c, Some(c) if is_whitespace(c) || is_newline(c))
-    }
 }
 
 /// Utility for boxing the state and returning a single-action transition

--- a/src/lexer/states/mod.rs
+++ b/src/lexer/states/mod.rs
@@ -1,6 +1,7 @@
 mod comments;
 mod identifiers;
 mod numbers;
+mod sql;
 mod start;
 mod symbols;
 mod text;

--- a/src/lexer/states/numbers.rs
+++ b/src/lexer/states/numbers.rs
@@ -98,7 +98,6 @@ impl State for InInteger {
     }
 }
 
-// TODO: This is another indication that the `can_terminate` logic needs overhauling
 fn can_terminate(c: Option<char>) -> bool {
     c.is_none()
         || matches!(c, Some(')'))

--- a/src/lexer/states/sql.rs
+++ b/src/lexer/states/sql.rs
@@ -1,0 +1,59 @@
+use crate::lexer::error::{LexError, LexErrorKind};
+use crate::lexer::tokens::{Token, TokenKind};
+use crate::lexer::prelude::*;
+use super::start::Start;
+
+/// State after receiving a backtick.
+#[derive(Debug)]
+pub(super) struct InSqlSelect(pub Stack);
+
+impl State for InSqlSelect {
+    fn receive(self: Box<Self>, ctx: &mut Context, c: Option<char>) -> ReceiveResult {
+        use LexErrorKind::UnclosedString;
+
+        let mut stack = self.0;
+
+        match c {
+            Some('`') => {
+                to(AfterSqlSelect(stack))
+            }
+            Some(c) => {
+                stack.push(c);
+                to(InSqlSelect(stack))
+            }
+            None => Err(LexError {
+                kind: UnclosedString,
+                position: ctx.current_position,
+            }),
+        }
+    }
+}
+
+/// State after receiving what might be a closing backtick unless the next
+/// character received is another backtick, which indicates the previous
+/// backtick was being escaped and is part of the SQL select statement.
+#[derive(Debug)]
+pub(super) struct AfterSqlSelect(pub Stack);
+
+impl State for AfterSqlSelect {
+    fn receive(self: Box<Self>, ctx: &mut Context, c: Option<char>) -> ReceiveResult {
+        let mut stack = self.0;
+
+        match c {
+            Some('`') => {
+                // Unlike when storing text strings or quoted identifiers, this does not
+                // need to preserve the double-backticks as part of the SQL fragment literal,
+                // since text strings and quoted identifiers have to remain properly escaped
+                // when passing to the database
+                stack.push('`');
+                to(InSqlSelect(stack))
+            }
+            _ => {
+                let position = stack.start_position;
+                let kind = TokenKind::SqlFragment(stack.consume());
+                ctx.add_token(Token { kind, position });
+                defer_to(Start, ctx, c)
+            }
+        }
+    }
+}

--- a/src/lexer/states/start.rs
+++ b/src/lexer/states/start.rs
@@ -3,8 +3,9 @@ use crate::lexer::tokens::{Symbol, Token, TokenKind};
 use crate::lexer::prelude::*;
 use super::identifiers::{InIdentifier, InQuotedIdentifier};
 use super::numbers::InInteger;
-use super::text::InText;
+use super::sql::InSqlSelect;
 use super::symbols::{AfterPeriod, AfterSingleDash};
+use super::text::InText;
 
 
 /// State corresponding to the start of input or after successfully extracting a token.
@@ -48,27 +49,31 @@ impl State for Start {
                 to(Start)
             }
             '.' => {
-                let stack = Stack::new(ctx.current_position, c);
+                let stack = Stack::new(ctx.current_position, Some(c));
                 to(AfterPeriod(stack))
             }
             '-' => {
-                let stack = Stack::new(ctx.current_position, c);
+                let stack = Stack::new(ctx.current_position, Some(c));
                 to(AfterSingleDash(stack))
             }
             '\'' => {
-                let stack = Stack::new(ctx.current_position, c);
+                let stack = Stack::new(ctx.current_position, Some(c));
                 to(InText(stack))
             }
             '"' => {
-                let stack = Stack::new(ctx.current_position, c);
+                let stack = Stack::new(ctx.current_position, Some(c));
                 to(InQuotedIdentifier(stack))
             }
+            '`' => {
+                let stack = Stack::new(ctx.current_position, None);
+                to(InSqlSelect(stack))
+            }
             '0'..='9' => {
-                let stack = Stack::new(ctx.current_position, c);
+                let stack = Stack::new(ctx.current_position, Some(c));
                 to(InInteger(stack))
             }
             c if is_identifier_char(c) => {
-                let stack = Stack::new(ctx.current_position, c);
+                let stack = Stack::new(ctx.current_position, Some(c));
                 to(InIdentifier(stack))
             }
             _ if is_whitespace(c) => {

--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -10,10 +10,12 @@ pub enum Keyword {
 
 impl fmt::Display for Keyword {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Keyword::*;
+
         match self {
-            Keyword::As => write!(f, "as"),
-            Keyword::Schema => write!(f, "schema"),
-            Keyword::Table => write!(f, "table"),
+            As => write!(f, "as"),
+            Schema => write!(f, "schema"),
+            Table => write!(f, "table"),
         }
     }
 }
@@ -30,13 +32,15 @@ pub enum Symbol {
 
 impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Symbol::*;
+
         match self {
-            Symbol::AtSign => write!(f, "@"),
-            Symbol::Comma => write!(f, ","),
-            Symbol::ParenLeft => write!(f, "("),
-            Symbol::ParenRight => write!(f, ")"),
-            Symbol::Period => write!(f, "."),
-            Symbol::Underscore => write!(f, "_"),
+            AtSign => write!(f, "@"),
+            Comma => write!(f, ","),
+            ParenLeft => write!(f, "("),
+            ParenRight => write!(f, ")"),
+            Period => write!(f, "."),
+            Underscore => write!(f, "_"),
         }
     }
 }
@@ -49,21 +53,25 @@ pub enum TokenKind {
     LineSep,
     Number(String),
     QuotedIdentifier(String),
+    SqlFragment(String),
     Symbol(Symbol),
     Text(String),
 }
 
 impl fmt::Display for TokenKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use TokenKind::*;
+
         match self {
-            TokenKind::Bool(b) => write!(f, "boolean `{}`", b),
-            TokenKind::Identifier(i) => write!(f, "identifier `{}`", i),
-            TokenKind::Keyword(k) => write!(f, "keyword `{}`", k),
-            TokenKind::LineSep => write!(f, "newline"),
-            TokenKind::Number(n) => write!(f, "number `{}`", n),
-            TokenKind::QuotedIdentifier(i) => write!(f, "quoted identifier `\"{}\"`", i),
-            TokenKind::Symbol(s) => write!(f, "symbol `{}`", s),
-            TokenKind::Text(s) => write!(f, "string '{}'", s),
+            Bool(b) => write!(f, "boolean `{}`", b),
+            Identifier(i) => write!(f, "identifier `{}`", i),
+            Keyword(k) => write!(f, "keyword `{}`", k),
+            LineSep => write!(f, "newline"),
+            Number(n) => write!(f, "number `{}`", n),
+            QuotedIdentifier(i) => write!(f, "quoted identifier `\"{}\"`", i),
+            SqlFragment(s) => write!(f, "SQL fragment `{}`", s),
+            Symbol(s) => write!(f, "symbol `{}`", s),
+            Text(s) => write!(f, "string '{}'", s),
         }
     }
 }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -150,7 +150,8 @@ impl<'a, 'b> FragmentRunner<'a, 'b> {
         //
         // Alternatively, maybe SQL fragments could be converted to CTEs in the
         // insert statement and the inserted values could be selected from the CTE
-        // and completely avoid the round-tripping in either protocol.
+        // and completely avoid the round-tripping in either protocol, but this
+        // would require a rewrite of the insert statement builder.
         let value = format!("'{}'", value.replace("'", "''"));
 
         Ok(value)

--- a/src/parser/nodes.rs
+++ b/src/parser/nodes.rs
@@ -85,6 +85,7 @@ pub enum Value {
     Bool(bool),
     Number(Box<String>),
     Reference(Box<Reference>),
+    SqlFragment(Box<String>),
     Text(Box<String>),
 }
 

--- a/src/parser/states.rs
+++ b/src/parser/states.rs
@@ -481,6 +481,11 @@ mod attribute_states {
                     ctx.push_attribute(attribute_name, value);
                     to(ReceivedAttributeValue)
                 }
+                TokenKind::SqlFragment(s) => {
+                    let value = nodes::Value::SqlFragment(Box::new(s));
+                    ctx.push_attribute(attribute_name, value);
+                    to(ReceivedAttributeValue)
+                }
                 TokenKind::Symbol(Symbol::AtSign) => to(ReceivedReferenceStart(attribute_name)),
                 TokenKind::Text(t) => {
                     let value = nodes::Value::Text(Box::new(t));


### PR DESCRIPTION
This PR adds support for SQL select fragment literals enclosed in `` ` `` characters, which was primarily inspired by shell/psql command substitution:

```
❯ sh

$ date
Thu May  2 09:11:02 EDT 2024

$ echo date
date

$ echo `date`
Thu May 2 09:11:06 EDT 2024

❯ psql

$ \echo `date`
Thu May  2 09:08:04 EDT 2024

$ \echo `echo date`
date

$ \echo `echo ``date```
Thu May  2 09:08:14 EDT 2024
```

The current strategy for executing the fragment selecting the value via simply query protocol, manually escaping any single quotes from the value, and then adding it as a text literal to the greater insert statement.

There are probably downsides to this approach, but alternatives include switching everything over to the extended query protocol which is a fairly large lift and has its own drawbacks, or maybe converting the SQL select fragments into CTEs in the insert statement, which would also be small-moderate lift. It might be worth pursuing if bugs are discovered with current behavior, though that then probably introduces complexity around verifying the fragment returns a single column from a single row.

Resolves https://github.com/crudecomputer/hldr/issues/59