### PR TITLE
Add implicit column references

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,45 @@ There are several supported reference formats:
 | Schema-qualified | `@myschema.mytable.record.column` | A previously-declared record in a table explicitly nested under a schema |
 | Table-qualified | `@mytable.record.column` | A previously-declared record in a top-level table not nested under a schema |
 | Record-qualified | `@record.column` | A previously-declared record in the same table scope as the current record being declared |
-| Column-qualified | `@column` | A previously-declared column in the same record being declared (**note:** the column being referenced is not required to be a literal value; it can be be another reference to a column or other record entirely) |
+| Column (unqualified) | `@column` | A previously-declared column in the same record being declared (**note:** the column being referenced is not required to be a literal value; it can be be another reference to a column or other record entirely) |
+
+Additionally, **qualified references** can *omit the column name* if it matches the attribute being assigned to:
+
+```
+table t (
+  rec ( some_column 'a value' )
+
+  -- These are equivalent; note the trailing period in the latter
+  ( some_column @rec.some_column )
+  ( some_column @rec. )
+)
+
+-- Supported in fully-qualified references as well
+schema myschema (
+  table mytable1 (
+    myrecord ( a_different_column true )
+  )
+  table mytable2 (
+    ( a_different_column @myschema.mytable1.myrecord. )
+  )
+)
+```
+
+Omitting the trailing period will cause `hldr` to interpret the final identifier in the reference
+as the column:
+
+```
+table mytable (
+  record1 (
+    some_column 'a value'
+  )
+
+  -- ERROR: No column `record1` in the record being declared
+  record2 (
+    some_column @record1
+  )
+)
+```
 
 ### Aliases
 
@@ -302,7 +340,7 @@ table pet (
 ### SQL Fragments
 
 Arbitrary `SELECT` statements can be embedded as values by using backticks and
-simply omitting the `SELECT` keyword.
+omitting the `SELECT` keyword.
 
 ```
 table t1 (

--- a/src/parser/nodes.rs
+++ b/src/parser/nodes.rs
@@ -83,19 +83,71 @@ impl Attribute {
 #[derive(Debug, PartialEq)]
 pub enum Value {
     Bool(bool),
-    Number(Box<String>),
-    Reference(Box<Reference>),
-    SqlFragment(Box<String>),
-    Text(Box<String>),
+    Number(String),
+    Reference(Reference),
+    SqlFragment(String),
+    Text(String),
 }
 
-// TODO: This should be handled by an enum, because this structure doesn't forbid
-// having a schema BUT not having a table, etc. and invalid situations should not
-// be representable.
+/// The set of possible reference types, with varying levels
+/// of qualification.
 #[derive(Debug, PartialEq)]
-pub struct Reference {
-    pub schema: Option<String>,
-    pub table: Option<String>,
-    pub record: Option<String>,
+pub enum Reference {
+    ColumnLevel(ColumnLevelReference),
+    RecordLevel(RecordLevelReference),
+    TableLevel(TableLevelReference),
+    SchemaLevel(SchemaLevelReference),
+}
+
+/// The set of possible column reference values, either explicit
+/// with a name or implicit without one, in which case the column
+/// being referenced is inferred from the attribute.
+#[derive(Debug, PartialEq)]
+pub enum ReferencedColumn {
+    Explicit(String),
+    Implicit,
+}
+
+/// References to a column in the same record, eg:
+///
+///     @column
+#[derive(Debug, PartialEq)]
+pub struct ColumnLevelReference {
     pub column: String,
+}
+
+/// References that are record-qualified with either explicit or implicit
+/// column reference, eg:
+///
+///     @record.column  -- explicit column
+///     @record.        -- implicit column
+#[derive(Debug, PartialEq)]
+pub struct RecordLevelReference {
+    pub record: String,
+    pub column: ReferencedColumn,
+}
+
+/// References that are table-qualified with either explicit or implicit
+/// column reference, eg:
+///
+///     @table.record.column  -- explicit column
+///     @table.record.        -- implicit column
+#[derive(Debug, PartialEq)]
+pub struct TableLevelReference {
+    pub table: String,
+    pub record: String,
+    pub column: ReferencedColumn,
+}
+
+/// References that are schema-qualified with either explicit or implicit
+/// column reference, eg:
+///
+///     @schema.table.record.column -- explicit column
+///     @schema.table.record.       -- implicit column
+#[derive(Debug, PartialEq)]
+pub struct SchemaLevelReference {
+    pub schema: String,
+    pub table: String,
+    pub record: String,
+    pub column: ReferencedColumn,
 }


### PR DESCRIPTION
Beyond adding support for implicit column references, the `parser::nodes::Reference` node has been converted [from a struct with several optional fields to an enum](https://github.com/crudecomputer/hldr/pull/63/files#diff-81c19d060b980f3a10aba83b18b9474f7ec13d6ab65ef8d851bd5fb1adac7fe6R95). The previous struct technically could allow conditions that should not exist (eg. a schema name but no table or record name), which would have been compounded when making the column name itself optional. Instead, there are now discrete types that only permit allowed reference states to be represented in the parse tree.

Resolves https://github.com/crudecomputer/hldr/issues/5