### PR TITLE
Support unqualified references

### DIFF
--- a/src/analyzer/error.rs
+++ b/src/analyzer/error.rs
@@ -1,13 +1,13 @@
 use std::error::Error;
 use std::fmt;
-// use crate::Position;
+use crate::Position;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum AnalyzeErrorKind {
     AmbiguousRecord { record: String },
     ColumnNotFound { column: String },
-    DuplicateColumn { scope: String, column: String },
-    DuplicateRecord { scope: String, record: String },
+    DuplicateColumn { column: String },
+    DuplicateRecord { record: String },
     RecordNotFound { record: String },
 }
 
@@ -17,17 +17,16 @@ impl fmt::Display for AnalyzeErrorKind {
 
         match self {
             AmbiguousRecord { record } => {
-                write!(f, "ambiguous record `{}`", record)
+                write!(f, "ambiguous record name `{}`", record)
             }
             ColumnNotFound { column } => {
                 write!(f, "referenced column `{}` not found", column)
             }
-            DuplicateColumn { scope, column } => {
-                // TODO: Need position
-                write!(f, "duplicate column `{}` in scope `{}`", column, scope)
+            DuplicateColumn { column } => {
+                write!(f, "duplicate column name `{}`", column)
             }
-            DuplicateRecord { scope, record } => {
-                write!(f, "duplicate record `{}` in scope `{}`", record, scope)
+            DuplicateRecord { record } => {
+                write!(f, "duplicate record name `{}`", record)
             }
             RecordNotFound { record } => {
                 write!(f, "record `{}` not found", record)
@@ -39,12 +38,12 @@ impl fmt::Display for AnalyzeErrorKind {
 #[derive(Debug, PartialEq)]
 pub struct AnalyzeError {
     pub kind: AnalyzeErrorKind,
-    // pub position: Position,
+    pub position: Position,
 }
 
 impl fmt::Display for AnalyzeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.kind)
+        write!(f, "{} ({})", self.kind, self.position)
     }
 }
 

--- a/src/analyzer/error.rs
+++ b/src/analyzer/error.rs
@@ -4,6 +4,7 @@ use std::fmt;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum AnalyzeErrorKind {
+    AmbiguousRecord { record: String },
     ColumnNotFound { column: String },
     DuplicateColumn { scope: String, column: String },
     DuplicateRecord { scope: String, record: String },
@@ -12,18 +13,23 @@ pub enum AnalyzeErrorKind {
 
 impl fmt::Display for AnalyzeErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use AnalyzeErrorKind::*;
+
         match self {
-            AnalyzeErrorKind::ColumnNotFound { column } => {
+            AmbiguousRecord { record } => {
+                write!(f, "ambiguous record `{}`", record)
+            }
+            ColumnNotFound { column } => {
                 write!(f, "referenced column `{}` not found", column)
             }
-            AnalyzeErrorKind::DuplicateColumn { scope, column } => {
+            DuplicateColumn { scope, column } => {
                 // TODO: Need position
                 write!(f, "duplicate column `{}` in scope `{}`", column, scope)
             }
-            AnalyzeErrorKind::DuplicateRecord { scope, record } => {
+            DuplicateRecord { scope, record } => {
                 write!(f, "duplicate record `{}` in scope `{}`", record, scope)
             }
-            AnalyzeErrorKind::RecordNotFound { record } => {
+            RecordNotFound { record } => {
                 write!(f, "record `{}` not found", record)
             }
         }

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -83,8 +83,8 @@ pub fn analyze(parse_tree: ParseTree) -> AnalyzeResult {
 }
 
 fn analyze_table(
-    schema: Option<&Schema>,
-    table: &Table,
+    schema: Option<&SchemaNode>,
+    table: &TableNode,
     refset: &mut RefSet,
 ) -> Result<(), AnalyzeError> {
     // TODO: This is mostly copy-pasta
@@ -115,9 +115,9 @@ fn analyze_table(
             if !refset.insert_record_scope(&table_scope, name) {
                 return Err(AnalyzeError {
                     kind: AnalyzeErrorKind::DuplicateRecord {
-                        scope: table_scope,
                         record: name.clone(),
                     },
+                    position: record.position,
                 });
             }
         }
@@ -127,7 +127,7 @@ fn analyze_table(
 }
 
 fn analyze_record(
-    record: &Record,
+    record: &RecordNode,
     refset: &RefSet,
     parent_scope: &str,
 ) -> Result<(), AnalyzeError> {
@@ -137,9 +137,9 @@ fn analyze_record(
         if !attrnames.insert(&attr.name) {
             return Err(AnalyzeError {
                 kind: AnalyzeErrorKind::DuplicateColumn {
-                    scope: parent_scope.to_owned(),
                     column: attr.name.clone(),
                 },
+                position: attr.position,
             });
         }
 
@@ -152,6 +152,7 @@ fn analyze_record(
                         kind: AnalyzeErrorKind::ColumnNotFound {
                             column: c.column.clone(),
                         },
+                        position: attr.position,
                     });
                 }
                 continue;
@@ -166,6 +167,7 @@ fn analyze_record(
                             kind: AnalyzeErrorKind::RecordNotFound {
                                 record: format!("{}.{}", scope, s.record),
                             },
+                            position: attr.position,
                         });
                     }
                 }
@@ -175,6 +177,7 @@ fn analyze_record(
                             kind: AnalyzeErrorKind::RecordNotFound {
                                 record: format!("{}.{}", t.table, t.record),
                             },
+                            position: attr.position,
                         });
                     }
                 }
@@ -185,6 +188,7 @@ fn analyze_record(
                                 kind: AnalyzeErrorKind::RecordNotFound {
                                     record: r.record.clone(),
                                 },
+                                position: attr.position,
                             });
                         }
                         Some(scopes) => {
@@ -204,6 +208,7 @@ fn analyze_record(
                                     kind: AnalyzeErrorKind::AmbiguousRecord {
                                         record: r.record.clone(),
                                     },
+                                    position: attr.position,
                                 });
                             }
                         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -61,8 +61,8 @@ mod tests {
         assert_eq!(
             parse(input),
             Ok(ParseTree {
-                nodes: vec![StructuralNode::Schema(Box::new(Schema {
-                    identity: StructuralIdentity {
+                nodes: vec![StructuralNode::Schema(Box::new(SchemaNode {
+                    identity: StructuralNodeIdentity {
                         alias: None,
                         name: "my_schema".to_owned(),
                     },
@@ -91,8 +91,8 @@ mod tests {
         assert_eq!(
             parse(input),
             Ok(ParseTree {
-                nodes: vec![StructuralNode::Schema(Box::new(Schema {
-                    identity: StructuralIdentity {
+                nodes: vec![StructuralNode::Schema(Box::new(SchemaNode {
+                    identity: StructuralNodeIdentity {
                         alias: Some("some_alias".to_owned()),
                         name: "my_other_schema".to_owned(),
                     },
@@ -131,8 +131,8 @@ mod tests {
         assert_eq!(
             parse(input),
             Ok(ParseTree {
-                nodes: vec![StructuralNode::Table(Box::new(Table {
-                    identity: StructuralIdentity {
+                nodes: vec![StructuralNode::Table(Box::new(TableNode {
+                    identity: StructuralNodeIdentity {
                         alias: None,
                         name: "my_table".to_owned(),
                     },
@@ -179,8 +179,8 @@ mod tests {
         assert_eq!(
             parse(input.into_iter()),
             Ok(ParseTree {
-                nodes: vec![StructuralNode::Table(Box::new(Table {
-                    identity: StructuralIdentity {
+                nodes: vec![StructuralNode::Table(Box::new(TableNode {
+                    identity: StructuralNodeIdentity {
                         alias: Some("another_alias".to_owned()),
                         name: "my_other_table".to_owned(),
                     },
@@ -204,13 +204,13 @@ mod tests {
         assert_eq!(
             parse(input),
             Ok(ParseTree {
-                nodes: vec![StructuralNode::Schema(Box::new(Schema {
-                    identity: StructuralIdentity {
+                nodes: vec![StructuralNode::Schema(Box::new(SchemaNode {
+                    identity: StructuralNodeIdentity {
                         alias: None,
                         name: "myschema".to_owned(),
                     },
-                    nodes: vec![Table {
-                        identity: StructuralIdentity {
+                    nodes: vec![TableNode {
+                        identity: StructuralNodeIdentity {
                             alias: None,
                             name: "mytable".to_owned(),
                         },
@@ -235,13 +235,13 @@ mod tests {
         assert_eq!(
             parse(input),
             Ok(ParseTree {
-                nodes: vec![StructuralNode::Schema(Box::new(Schema {
-                    identity: StructuralIdentity {
+                nodes: vec![StructuralNode::Schema(Box::new(SchemaNode {
+                    identity: StructuralNodeIdentity {
                         alias: Some("s1".to_owned()),
                         name: "myschema".to_owned(),
                     },
-                    nodes: vec![Table {
-                        identity: StructuralIdentity {
+                    nodes: vec![TableNode {
+                        identity: StructuralNodeIdentity {
                             alias: Some("t1".to_owned()),
                             name: "mytable".to_owned(),
                         },
@@ -275,35 +275,35 @@ mod tests {
             parse(input),
             Ok(ParseTree {
                 nodes: vec![
-                    StructuralNode::Schema(Box::new(Schema {
-                        identity: StructuralIdentity {
+                    StructuralNode::Schema(Box::new(SchemaNode {
+                        identity: StructuralNodeIdentity {
                             alias: None,
                             name: "s1".to_owned(),
                         },
-                        nodes: vec![Table {
-                            identity: StructuralIdentity {
+                        nodes: vec![TableNode {
+                            identity: StructuralNodeIdentity {
                                 alias: None,
                                 name: "t1".to_owned(),
                             },
                             nodes: vec![
-                                Record {
+                                RecordNode {
                                     name: Some("record1".to_owned()),
                                     nodes: Vec::new(),
                                 },
-                                Record::default(),
-                                Record::default(),
+                                RecordNode::default(),
+                                RecordNode::default(),
                             ],
                         },],
                     })),
-                    StructuralNode::Table(Box::new(Table {
-                        identity: StructuralIdentity {
+                    StructuralNode::Table(Box::new(TableNode {
+                        identity: StructuralNodeIdentity {
                             alias: None,
                             name: "t2".to_owned(),
                         },
                         nodes: vec![
-                            Record::default(),
-                            Record::default(),
-                            Record {
+                            RecordNode::default(),
+                            RecordNode::default(),
+                            RecordNode {
                                 name: Some("record2".to_owned()),
                                 nodes: Vec::new(),
                             },
@@ -354,28 +354,28 @@ mod tests {
         "#,
         );
 
-        let t1 = Table {
-            identity: StructuralIdentity {
+        let t1 = TableNode {
+            identity: StructuralNodeIdentity {
                 alias: None,
                 name: "t1".to_owned(),
             },
             nodes: vec![
-                Record {
+                RecordNode {
                     name: Some("record1".to_owned()),
                     nodes: vec![
-                        Attribute {
+                        AttributeNode {
                             name: "col1".to_owned(),
                             value: Value::Number(Box::new("123".to_owned())),
                         },
-                        Attribute {
+                        AttributeNode {
                             name: "col2".to_owned(),
                             value: Value::Bool(true),
                         },
-                        Attribute {
+                        AttributeNode {
                             name: "col3".to_owned(),
                             value: Value::Text(Box::new("'hello!'".to_owned())),
                         },
-                        Attribute {
+                        AttributeNode {
                             name: "col4".to_owned(),
                             value: Value::Reference(Box::new(Reference {
                                 schema: None,
@@ -386,9 +386,9 @@ mod tests {
                         },
                     ],
                 },
-                Record {
+                RecordNode {
                     name: None,
-                    nodes: vec![Attribute {
+                    nodes: vec![AttributeNode {
                         name: "col".to_owned(),
                         value: Value::Reference(Box::new(Reference {
                             schema: None,
@@ -400,15 +400,15 @@ mod tests {
                 },
             ],
         };
-        let t2 = Table {
-            identity: StructuralIdentity {
+        let t2 = TableNode {
+            identity: StructuralNodeIdentity {
                 alias: None,
                 name: "t2".to_owned(),
             },
             nodes: vec![
-                Record {
+                RecordNode {
                     name: None,
-                    nodes: vec![Attribute {
+                    nodes: vec![AttributeNode {
                         name: "colx".to_owned(),
                         value: Value::Reference(Box::new(Reference {
                             schema: Some("s1".to_owned()),
@@ -418,9 +418,9 @@ mod tests {
                         })),
                     }],
                 },
-                Record {
+                RecordNode {
                     name: None,
-                    nodes: vec![Attribute {
+                    nodes: vec![AttributeNode {
                         name: "coly".to_owned(),
                         value: Value::Reference(Box::new(Reference {
                             // TODO: Should these actually be explicitly quoted?
@@ -431,24 +431,24 @@ mod tests {
                         })),
                     }],
                 },
-                Record {
+                RecordNode {
                     name: Some("record2".to_owned()),
-                    nodes: vec![Attribute {
+                    nodes: vec![AttributeNode {
                         name: "col".to_owned(),
                         value: Value::Number(Box::new("1234".to_owned())),
                     }],
                 },
-                Record::default(),
+                RecordNode::default(),
             ],
         };
-        let t3 = Table {
-            identity: StructuralIdentity {
+        let t3 = TableNode {
+            identity: StructuralNodeIdentity {
                 alias: None,
                 name: "t3".to_owned(),
             },
-            nodes: vec![Record {
+            nodes: vec![RecordNode {
                 name: None,
-                nodes: vec![Attribute {
+                nodes: vec![AttributeNode {
                     name: "col".to_owned(),
                     value: Value::Reference(Box::new(Reference {
                         schema: None,
@@ -462,8 +462,8 @@ mod tests {
 
         let expected = Ok(ParseTree {
             nodes: vec![
-                StructuralNode::Schema(Box::new(Schema {
-                    identity: StructuralIdentity {
+                StructuralNode::Schema(Box::new(SchemaNode {
+                    identity: StructuralNodeIdentity {
                         alias: None,
                         name: "s1".to_owned(),
                     },

--- a/src/parser/nodes.rs
+++ b/src/parser/nodes.rs
@@ -1,3 +1,5 @@
+use crate::Position;
+
 #[derive(Debug, Default, PartialEq)]
 pub struct ParseTree {
     pub nodes: Vec<StructuralNode>,
@@ -5,31 +7,31 @@ pub struct ParseTree {
 
 #[derive(Debug, PartialEq)]
 pub enum StructuralNode {
-    Schema(Box<Schema>),
-    Table(Box<Table>),
+    Schema(Box<SchemaNode>),
+    Table(Box<TableNode>),
 }
 
 #[derive(Debug, PartialEq)]
-pub struct StructuralIdentity {
+pub struct StructuralNodeIdentity {
     pub alias: Option<String>,
     pub name: String,
 }
 
-impl StructuralIdentity {
+impl StructuralNodeIdentity {
     pub fn new(name: String, alias: Option<String>) -> Self {
         Self { alias, name }
     }
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Schema {
-    pub identity: StructuralIdentity,
-    pub nodes: Vec<Table>,
+pub struct SchemaNode {
+    pub identity: StructuralNodeIdentity,
+    pub nodes: Vec<TableNode>,
 }
 
-impl Schema {
+impl SchemaNode {
     pub fn new(name: String, alias: Option<String>) -> Self {
-        let identity = StructuralIdentity::new(name, alias);
+        let identity = StructuralNodeIdentity::new(name, alias);
         Self {
             identity,
             nodes: Vec::new(),
@@ -38,14 +40,14 @@ impl Schema {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Table {
-    pub identity: StructuralIdentity,
-    pub nodes: Vec<Record>,
+pub struct TableNode {
+    pub identity: StructuralNodeIdentity,
+    pub nodes: Vec<RecordNode>,
 }
 
-impl Table {
+impl TableNode {
     pub fn new(name: String, alias: Option<String>) -> Self {
-        let identity = StructuralIdentity::new(name, alias);
+        let identity = StructuralNodeIdentity::new(name, alias);
         Self {
             identity,
             nodes: Vec::new(),
@@ -54,29 +56,32 @@ impl Table {
 }
 
 #[derive(Debug, Default, PartialEq)]
-pub struct Record {
+pub struct RecordNode {
     pub name: Option<String>,
-    pub nodes: Vec<Attribute>,
+    pub nodes: Vec<AttributeNode>,
+    pub position: Position,
 }
 
-impl Record {
-    pub fn new(name: Option<String>) -> Self {
+impl RecordNode {
+    pub fn new(name: Option<String>, position: Position) -> Self {
         Self {
             name,
             nodes: Vec::new(),
+            position,
         }
     }
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Attribute {
+pub struct AttributeNode {
     pub name: String,
     pub value: Value,
+    pub position: Position,
 }
 
-impl Attribute {
-    pub fn new(name: String, value: Value) -> Self {
-        Self { name, value }
+impl AttributeNode {
+    pub fn new(name: String, value: Value, position: Position) -> Self {
+        Self { name, value, position }
     }
 }
 


### PR DESCRIPTION
This PR introduces the ability to reference records from other tables and schemas without qualification, provided that there is no ambiguity, either because...
- ... there is, at the point a reference is used, only a single record with that given name has been observed across all previously-declared scopes, or...
- ... there have been multiple records across difference scopes with the same name, but one exists in the current table scope and takes precedence over all others

**TODO**

- [x] Update analyzer
- [ ] Update loader
- [ ] Update README (specifically the record-qualified table row)


Resolves https://github.com/crudecomputer/hldr/issues/33